### PR TITLE
Fix dir() function to work with init.lua files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod lua_executor;
 mod gatekeeper;
 
-pub use gatekeeper::{GatekeeperResult, load_and_evaluate_gatekeeper};
+pub use gatekeeper::{GatekeeperResult, load_and_evaluate_gatekeeper, load_and_evaluate_gatekeeper_with_context};


### PR DESCRIPTION
The dir() function was failing to determine the current directory when called from init.lua files, causing directory aggregates to return incorrect results

Root cause: load_and_evaluate_gatekeeper() created a new Lua VM without the parent directory context needed by dir().

Fix:
- Auto-detect init.lua files in load_and_evaluate_gatekeeper()
- Extract parent directory from resolved path
- Add load_and_evaluate_gatekeeper_with_context() to pass directory
- Add LuaExecutor::set_current_dir() to set _DOTGK_CURRENT_DIR global
- Simplify require loader (auto-detection handles context now)