### PR TITLE
Fix os/linux test to be portable across operating systems

### DIFF
--- a/src/gatekeeper.rs
+++ b/src/gatekeeper.rs
@@ -248,7 +248,8 @@ mod tests {
 
     #[test]
     fn test_subdirectory_gatekeeper_os_linux() -> Result<()> {
-        test_helper("os/linux", true)
+        let expected = cfg!(target_os = "linux");
+        test_helper("os/linux", expected)
     }
 
     #[test]


### PR DESCRIPTION
The test_subdirectory_gatekeeper_os_linux test was hardcoded to expect true, causing it to fail on macOS. Update it to use cfg!(target_os) like the other OS-specific tests.

All 101 tests now pass on Linux, macOS, and Windows.